### PR TITLE
Option to clear presence when music is not playing and bugfixes

### DIFF
--- a/DiscordBee.cs
+++ b/DiscordBee.cs
@@ -34,8 +34,8 @@ namespace MusicBeePlugin
       _about.TargetApplication = "";   // current only applies to artwork, lyrics or instant messenger name that appears in the provider drop down selector or target Instant Messenger
       _about.Type = PluginType.General;
       _about.VersionMajor = 1;  // your plugin version
-      _about.VersionMinor = 1;
-      _about.Revision = 1;
+      _about.VersionMinor = 2;
+      _about.Revision = 0;
       _about.MinInterfaceVersion = MinInterfaceVersion;
       _about.MinApiRevision = MinApiRevision;
       _about.ReceiveNotifications = (ReceiveNotificationFlags.PlayerEvents | ReceiveNotificationFlags.TagEvents);
@@ -92,6 +92,11 @@ namespace MusicBeePlugin
     {
       _discordUpdateTimer.Stop();
       Debug.WriteLine("Disconnected: " + errorCode + " Msg: " + message);
+    }
+
+    public string GetVersionString()
+    {
+      return "" + _about.VersionMajor + "." + _about.VersionMinor + "." + _about.Revision;
     }
 
     public bool Configure(IntPtr panelHandle)
@@ -276,8 +281,16 @@ namespace MusicBeePlugin
           presField.SetValue(_discordPresence, value + "\u180E");
         }
       }
-
-      if (!_discordUpdateTimer.Enabled) _discordUpdateTimer.Start();
+      
+      if (!_settings.UpdatePresenceWhenStopped && (playerGetPlayState == PlayState.Paused || playerGetPlayState == PlayState.Stopped))
+      {
+        _discordUpdateTimer.Stop();
+        DiscordRpc.ClearPresence();
+      }
+      else if (!_discordUpdateTimer.Enabled)
+      {
+        _discordUpdateTimer.Start();
+      }
     }
   }
 }

--- a/SettingsWindow.Designer.cs
+++ b/SettingsWindow.Designer.cs
@@ -44,6 +44,7 @@
       this.buttonRestoreDefaults = new System.Windows.Forms.Button();
       this.buttonSaveClose = new System.Windows.Forms.Button();
       this.buttonPlaceholders = new System.Windows.Forms.Button();
+      this.checkBoxPresenceUpdate = new System.Windows.Forms.CheckBox();
       ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).BeginInit();
       this.splitContainer1.Panel1.SuspendLayout();
       this.splitContainer1.Panel2.SuspendLayout();
@@ -204,6 +205,7 @@
       // 
       // splitContainer2.Panel1
       // 
+      this.splitContainer2.Panel1.Controls.Add(this.checkBoxPresenceUpdate);
       this.splitContainer2.Panel1.Controls.Add(this.textBoxSeperator);
       this.splitContainer2.Panel1.Controls.Add(this.label5);
       // 
@@ -273,6 +275,17 @@
       this.buttonPlaceholders.UseVisualStyleBackColor = true;
       this.buttonPlaceholders.Click += new System.EventHandler(this.buttonPlaceholders_Click);
       // 
+      // checkBoxPresenceUpdate
+      // 
+      this.checkBoxPresenceUpdate.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+      this.checkBoxPresenceUpdate.AutoSize = true;
+      this.checkBoxPresenceUpdate.Location = new System.Drawing.Point(272, 5);
+      this.checkBoxPresenceUpdate.Name = "checkBoxPresenceUpdate";
+      this.checkBoxPresenceUpdate.Size = new System.Drawing.Size(220, 17);
+      this.checkBoxPresenceUpdate.TabIndex = 5;
+      this.checkBoxPresenceUpdate.Text = "Show presence when no music is playing";
+      this.checkBoxPresenceUpdate.UseVisualStyleBackColor = true;
+      // 
       // SettingsWindow
       // 
       this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -317,5 +330,6 @@
     private System.Windows.Forms.TextBox textBoxSeperator;
     private System.Windows.Forms.Label label5;
     private System.Windows.Forms.Button buttonRestoreDefaults;
+    private System.Windows.Forms.CheckBox checkBoxPresenceUpdate;
   }
 }

--- a/SettingsWindow.cs
+++ b/SettingsWindow.cs
@@ -18,6 +18,7 @@ namespace MusicBeePlugin
       _defaultSettings = new Settings();
       InitializeComponent();
       UpdateValues(_settings);
+      Text += " (v" + parent.GetVersionString() + ")";
 
       FormClosing += OnFormClosing;
       Shown += OnShown;
@@ -52,6 +53,7 @@ namespace MusicBeePlugin
       textBoxState.Text = settings.PresenceState;
       textBoxImage.Text = settings.ImageText;
       textBoxSeperator.Text = settings.Seperator;
+      checkBoxPresenceUpdate.Checked = settings.UpdatePresenceWhenStopped;
     }
 
     private void buttonPlaceholders_Click(object sender, EventArgs e)
@@ -72,32 +74,40 @@ namespace MusicBeePlugin
       if (textBoxTrackNo.Text != _defaultSettings.PresenceTrackNo)
       {
         _settings.PresenceTrackNo = textBoxTrackNo.Text;
+        _defaultsRestored = false;
       }
 
       if (textBoxTrackCnt.Text != _defaultSettings.PresenceTrackCnt)
       {
         _settings.PresenceTrackCnt = textBoxTrackCnt.Text;
+        _defaultsRestored = false;
       }
 
       if (textBoxDetails.Text != _defaultSettings.PresenceDetails)
       {
         _settings.PresenceDetails = textBoxDetails.Text;
+        _defaultsRestored = false;
       }
 
       if (textBoxState.Text != _defaultSettings.PresenceState)
       {
         _settings.PresenceState = textBoxState.Text;
+        _defaultsRestored = false;
       }
 
       if (textBoxImage.Text != _defaultSettings.ImageText)
       {
         _settings.ImageText = textBoxImage.Text;
+        _defaultsRestored = false;
       }
 
       if (textBoxSeperator.Text != _defaultSettings.Seperator)
       {
         _settings.Seperator = textBoxSeperator.Text;
+        _defaultsRestored = false;
       }
+
+     _settings.UpdatePresenceWhenStopped = checkBoxPresenceUpdate.Checked;
 
       if (_defaultsRestored)
       {


### PR DESCRIPTION
- add option to clear presence when music is not playing
- fix a bug where if the restore buton is pressed all changes made before pressing save would get lost
- add Version to settingswindow title
- increase version to 1.2.0

fixes #12