### PR TITLE
Fix party showing 1 of 1 in certain cases where it should not be shown at all

### DIFF
--- a/DiscordBee.cs
+++ b/DiscordBee.cs
@@ -237,10 +237,9 @@ namespace MusicBeePlugin
       }
 
       _discordPresence.Details = padString(_layoutHandler.Render(_settings.PresenceDetails, metaDataDict, _settings.Seperator));
-      _discordPresence.Party.ID = "aaaa";
 
-      var trackcnt = 0;
-      var trackno = 0;
+      var trackcnt = -1;
+      var trackno = -1;
       try
       {
         trackcnt = int.Parse(_layoutHandler.Render(_settings.PresenceTrackCnt, metaDataDict, _settings.Seperator));
@@ -250,8 +249,20 @@ namespace MusicBeePlugin
       {
         // ignored
       }
-      _discordPresence.Party.Max = trackcnt;
-      _discordPresence.Party.Size = trackno;
+
+      if (trackcnt < trackno || trackcnt <= 0 || trackno <= 0)
+      {
+        _discordPresence.Party = null;
+      }
+      else
+      {
+        _discordPresence.Party = new Party
+        {
+          ID = "aaaa",
+          Max = trackcnt,
+          Size = trackno
+        };
+      }
 
       if (!_settings.UpdatePresenceWhenStopped && (playerGetPlayState == PlayState.Paused || playerGetPlayState == PlayState.Stopped))
       {

--- a/README.md
+++ b/README.md
@@ -41,6 +41,6 @@ If you are unhappy with your changes, you can always restore the defaults and sa
 Feel free to send pull requests or open issues. The project is a Visual Studio 2017 Solution. 
 
 ## Libraries and Assets used
- - [Discord RPC](https://github.com/discordapp/discord-rpc)
+ - [Discord RPC Sharp](https://github.com/Lachee/discord-rpc-csharp)
  - [Icons](https://www.iconfinder.com/iconsets/media-player-long-shadow)
  - [MusicBee Logo](https://github.com/Avik-B/musicbee-website/blob/master/img/mb_icon_touch.png)


### PR DESCRIPTION
DiscordRPCSharp seems to handle invalid party counts differently than the Discord SDK did
so it is required to sanitize the size before giving it to the library

fixes #27
fixes #29