### PR TITLE
Allow using/escaping brackets in layout handler

### DIFF
--- a/DiscordBee.cs
+++ b/DiscordBee.cs
@@ -48,7 +48,7 @@ namespace MusicBeePlugin
       _discordClient.DiscordId = _settings.DiscordAppId;
 
       // Match least number of chars possible but min 1
-      _layoutHandler = new LayoutHandler(new Regex("\\[(.+?)\\]"));
+      _layoutHandler = new LayoutHandler(new Regex("\\[([^[]+?)\\]"));
 
       _updateTimer.Elapsed += _updateTimer_Elapsed;
       _updateTimer.AutoReset = false;


### PR DESCRIPTION
For example I use the following (with this PR).

`[AlbumArtist] - [Album] [[YearOnly]]`
![image](https://user-images.githubusercontent.com/6632271/148643656-4e2b1f92-3a34-4981-b7ba-a7834c374664.png)
