### PR TITLE
Use AlbumArtist instead of Artist as default state

### DIFF
--- a/Settings.cs
+++ b/Settings.cs
@@ -20,7 +20,7 @@ namespace MusicBeePlugin
       {"LargeImageText", "MusicBee"},
       {"SmallImageText", "[Volume]%"},
       {"PresenceState", "[TrackTitle]"},
-      {"PresenceDetails", "[Artist] - [Album]"},
+      {"PresenceDetails", "[AlbumArtist] - [Album]"},
       {"PresenceTrackCnt", "[TrackCount]"},
       {"PresenceTrackNo", "[TrackNo]"},
       {"DiscordAppId", "409394531948298250"}, // prod


### PR DESCRIPTION
`Artist` is every artist that contributed to the song.

Most people would prefer `AlbumArtist` I think, because the space is quite limited.