### PR TITLE
Implement custom button

### DIFF
--- a/DiscordBee.cs
+++ b/DiscordBee.cs
@@ -5,6 +5,8 @@ namespace MusicBeePlugin
   using System;
   using System.Collections.Generic;
   using System.Diagnostics;
+  using System.Linq;
+  using System.Net;
   using System.Text;
   using System.Text.RegularExpressions;
   using System.Timers;
@@ -223,6 +225,37 @@ namespace MusicBeePlugin
           }
         }
         return input;
+      }
+
+      // Button Functionality
+      if (_settings.ShowButton)
+      {
+        var uri = _settings.ButtonUrl
+          .Split('/')
+          .Select(part =>
+          {
+            var result = _layoutHandler.Render(part, metaDataDict, _settings.Seperator);
+            if (part != result && (part != "_"))
+            {
+              return WebUtility.UrlEncode(result);
+            }
+
+            return part;
+          });
+
+        // Validate the URL again.
+        var finalUrl = string.Join("/", uri);
+        if (ValidationHelpers.ValidateUri(finalUrl))
+        {
+          _discordPresence.Buttons = new Button[]
+          {
+            new Button
+            {
+              Label = padString(_settings.ButtonLabel),
+              Url = finalUrl
+            }
+          };
+        }
       }
 
       void SetImage(string name, bool forceHideSmallImage = false)

--- a/DiscordBee.csproj
+++ b/DiscordBee.csproj
@@ -111,6 +111,7 @@
     <Compile Include="SettingsWindow.Designer.cs">
       <DependentUpon>SettingsWindow.cs</DependentUpon>
     </Compile>
+    <Compile Include="ValidationHelpers.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include=".editorconfig" />

--- a/Settings.cs
+++ b/Settings.cs
@@ -7,6 +7,7 @@ namespace MusicBeePlugin
   using System.Reflection;
   using System.Runtime.Serialization;
   using System.Xml;
+  using DiscordRPC;
 
   [DataContract]
   public class Settings
@@ -23,6 +24,8 @@ namespace MusicBeePlugin
       {"PresenceDetails", "[Artist] - [Album]"},
       {"PresenceTrackCnt", "[TrackCount]"},
       {"PresenceTrackNo", "[TrackNo]"},
+      {"ButtonLabel", "View Last.fm Info"},
+      {"ButtonUrl", "https://www.last.fm/music/[Artist]/_/[TrackTitle]"},
       {"DiscordAppId", "409394531948298250"}, // prod
       //{"DiscordAppId", "408977077799354379"}, // dev
     };
@@ -175,6 +178,46 @@ namespace MusicBeePlugin
           OnSettingChanged(eventArgs);
         }
       }
+    }
+
+    [DataMember] private string _buttonLabel;
+
+    public string ButtonLabel
+    {
+      get => string.IsNullOrEmpty(_buttonLabel) ? defaults["ButtonLabel"] : _buttonLabel;
+      set
+      {
+        if (value != null && value.Equals(defaults["ButtonLabel"]))
+        {
+          _buttonLabel = null;
+          return;
+        }
+        setIfChanged("_buttonLabel", value);
+      }
+    }
+
+    [DataMember] private string _buttonUrl;
+
+    public string ButtonUrl
+    {
+      get => string.IsNullOrEmpty(_buttonUrl) ? defaults["ButtonUrl"] : _buttonUrl;
+      set
+      {
+        if (value != null && value.Equals(defaults["ButtonUrl"]))
+        {
+          _buttonUrl = null;
+          return;
+        }
+        setIfChanged("_buttonUrl", value);
+      }
+    }
+
+    [DataMember] private bool? _showButton;
+
+    public bool ShowButton
+    {
+      get => _showButton.HasValue && _showButton.Value;
+      set => setIfChanged("_showButton", value);
     }
 
     #endregion

--- a/SettingsWindow.Designer.cs
+++ b/SettingsWindow.Designer.cs
@@ -47,6 +47,8 @@ namespace MusicBeePlugin
       this.buttonSaveClose = new System.Windows.Forms.Button();
       this.buttonPlaceholders = new System.Windows.Forms.Button();
       this.panel2 = new System.Windows.Forms.Panel();
+      this.customButtonToggle = new System.Windows.Forms.CheckBox();
+      this.checkBoxShowOnlyNonPlayingState = new System.Windows.Forms.CheckBox();
       this.checkBoxShowPlayState = new System.Windows.Forms.CheckBox();
       this.checkBoxShowTime = new System.Windows.Forms.CheckBox();
       this.checkBoxArtworkUpload = new System.Windows.Forms.CheckBox();
@@ -54,247 +56,237 @@ namespace MusicBeePlugin
       this.textBoxDiscordAppId = new System.Windows.Forms.TextBox();
       this.panel3 = new System.Windows.Forms.Panel();
       this.panel4 = new System.Windows.Forms.Panel();
-      this.checkBoxShowOnlyNonPlayingState = new System.Windows.Forms.CheckBox();
+      this.label9 = new System.Windows.Forms.Label();
+      this.customButtonUrl = new System.Windows.Forms.TextBox();
+      this.label8 = new System.Windows.Forms.Label();
+      this.customButtonLabel = new System.Windows.Forms.TextBox();
       this.panel2.SuspendLayout();
       this.panel3.SuspendLayout();
       this.panel4.SuspendLayout();
       this.SuspendLayout();
-      // 
+      //
       // textBoxSmallImage
-      // 
+      //
       this.textBoxSmallImage.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(114)))), ((int)(((byte)(137)))), ((int)(((byte)(218)))));
       this.textBoxSmallImage.Font = new System.Drawing.Font("Arial", 11.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
       this.textBoxSmallImage.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(226)))), ((int)(((byte)(230)))), ((int)(((byte)(246)))));
-      this.textBoxSmallImage.Location = new System.Drawing.Point(18, 109);
-      this.textBoxSmallImage.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+      this.textBoxSmallImage.Location = new System.Drawing.Point(12, 71);
       this.textBoxSmallImage.Name = "textBoxSmallImage";
-      this.textBoxSmallImage.Size = new System.Drawing.Size(133, 33);
+      this.textBoxSmallImage.Size = new System.Drawing.Size(90, 25);
       this.textBoxSmallImage.TabIndex = 9;
       this.textBoxSmallImage.Text = "Small Image Text";
-      // 
+      //
       // label4
-      // 
+      //
       this.label4.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
       this.label4.AutoSize = true;
       this.label4.Font = new System.Drawing.Font("Arial", 11.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
       this.label4.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(226)))), ((int)(((byte)(230)))), ((int)(((byte)(246)))));
-      this.label4.Location = new System.Drawing.Point(716, 102);
-      this.label4.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+      this.label4.Location = new System.Drawing.Point(492, 66);
       this.label4.Name = "label4";
-      this.label4.Size = new System.Drawing.Size(20, 26);
+      this.label4.Size = new System.Drawing.Size(13, 17);
       this.label4.TabIndex = 8;
       this.label4.Text = ")";
-      // 
+      //
       // textBoxTrackCnt
-      // 
+      //
       this.textBoxTrackCnt.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
       this.textBoxTrackCnt.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(114)))), ((int)(((byte)(137)))), ((int)(((byte)(218)))));
       this.textBoxTrackCnt.Font = new System.Drawing.Font("Arial", 11.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
       this.textBoxTrackCnt.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(226)))), ((int)(((byte)(230)))), ((int)(((byte)(246)))));
-      this.textBoxTrackCnt.Location = new System.Drawing.Point(598, 97);
-      this.textBoxTrackCnt.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+      this.textBoxTrackCnt.Location = new System.Drawing.Point(414, 63);
       this.textBoxTrackCnt.Name = "textBoxTrackCnt";
-      this.textBoxTrackCnt.Size = new System.Drawing.Size(109, 33);
+      this.textBoxTrackCnt.Size = new System.Drawing.Size(74, 25);
       this.textBoxTrackCnt.TabIndex = 7;
       this.textBoxTrackCnt.Text = "PartyMax";
-      // 
+      //
       // label3
-      // 
+      //
       this.label3.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
       this.label3.AutoSize = true;
       this.label3.Font = new System.Drawing.Font("Arial", 11.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
       this.label3.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(226)))), ((int)(((byte)(230)))), ((int)(((byte)(246)))));
-      this.label3.Location = new System.Drawing.Point(560, 102);
-      this.label3.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+      this.label3.Location = new System.Drawing.Point(388, 66);
       this.label3.Name = "label3";
-      this.label3.Size = new System.Drawing.Size(32, 26);
+      this.label3.Size = new System.Drawing.Size(20, 17);
       this.label3.TabIndex = 6;
       this.label3.Text = "of";
-      // 
+      //
       // textBoxTrackNo
-      // 
+      //
       this.textBoxTrackNo.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
       this.textBoxTrackNo.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(114)))), ((int)(((byte)(137)))), ((int)(((byte)(218)))));
       this.textBoxTrackNo.Font = new System.Drawing.Font("Arial", 11.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
       this.textBoxTrackNo.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(226)))), ((int)(((byte)(230)))), ((int)(((byte)(246)))));
-      this.textBoxTrackNo.Location = new System.Drawing.Point(442, 97);
-      this.textBoxTrackNo.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+      this.textBoxTrackNo.Location = new System.Drawing.Point(310, 63);
       this.textBoxTrackNo.Name = "textBoxTrackNo";
-      this.textBoxTrackNo.Size = new System.Drawing.Size(109, 33);
+      this.textBoxTrackNo.Size = new System.Drawing.Size(74, 25);
       this.textBoxTrackNo.TabIndex = 5;
       this.textBoxTrackNo.Text = "PartyNo";
-      // 
+      //
       // label2
-      // 
+      //
       this.label2.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
       this.label2.AutoSize = true;
       this.label2.Font = new System.Drawing.Font("Arial", 11.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
       this.label2.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(226)))), ((int)(((byte)(230)))), ((int)(((byte)(246)))));
-      this.label2.Location = new System.Drawing.Point(414, 102);
-      this.label2.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+      this.label2.Location = new System.Drawing.Point(291, 66);
       this.label2.Name = "label2";
-      this.label2.Size = new System.Drawing.Size(20, 26);
+      this.label2.Size = new System.Drawing.Size(13, 17);
       this.label2.TabIndex = 4;
       this.label2.Text = "(";
-      // 
+      //
       // textBoxState
-      // 
-      this.textBoxState.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
-      | System.Windows.Forms.AnchorStyles.Right)));
+      //
+      this.textBoxState.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) | System.Windows.Forms.AnchorStyles.Right)));
       this.textBoxState.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(114)))), ((int)(((byte)(137)))), ((int)(((byte)(218)))));
       this.textBoxState.Font = new System.Drawing.Font("Arial", 11.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
       this.textBoxState.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(226)))), ((int)(((byte)(230)))), ((int)(((byte)(246)))));
-      this.textBoxState.Location = new System.Drawing.Point(162, 97);
-      this.textBoxState.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+      this.textBoxState.Location = new System.Drawing.Point(108, 63);
       this.textBoxState.Name = "textBoxState";
-      this.textBoxState.Size = new System.Drawing.Size(241, 33);
+      this.textBoxState.Size = new System.Drawing.Size(177, 25);
       this.textBoxState.TabIndex = 3;
       this.textBoxState.Text = "Presence state";
-      // 
+      //
       // textBoxDetails
-      // 
-      this.textBoxDetails.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
-      | System.Windows.Forms.AnchorStyles.Right)));
+      //
+      this.textBoxDetails.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) | System.Windows.Forms.AnchorStyles.Right)));
       this.textBoxDetails.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(114)))), ((int)(((byte)(137)))), ((int)(((byte)(218)))));
       this.textBoxDetails.Font = new System.Drawing.Font("Arial", 11.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
       this.textBoxDetails.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(226)))), ((int)(((byte)(230)))), ((int)(((byte)(246)))));
-      this.textBoxDetails.Location = new System.Drawing.Point(162, 49);
-      this.textBoxDetails.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+      this.textBoxDetails.Location = new System.Drawing.Point(108, 32);
       this.textBoxDetails.Name = "textBoxDetails";
-      this.textBoxDetails.Size = new System.Drawing.Size(390, 33);
+      this.textBoxDetails.Size = new System.Drawing.Size(276, 25);
       this.textBoxDetails.TabIndex = 2;
       this.textBoxDetails.Text = "Presence details";
-      // 
+      //
       // label1
-      // 
+      //
       this.label1.AutoSize = true;
       this.label1.Font = new System.Drawing.Font("Arial", 12F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
       this.label1.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(226)))), ((int)(((byte)(230)))), ((int)(((byte)(246)))));
-      this.label1.Location = new System.Drawing.Point(162, 15);
-      this.label1.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+      this.label1.Location = new System.Drawing.Point(108, 10);
       this.label1.Name = "label1";
-      this.label1.Size = new System.Drawing.Size(125, 29);
+      this.label1.Size = new System.Drawing.Size(84, 19);
       this.label1.TabIndex = 1;
       this.label1.Text = "MusicBee";
-      // 
+      //
       // textBoxLargeImage
-      // 
+      //
       this.textBoxLargeImage.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(114)))), ((int)(((byte)(137)))), ((int)(((byte)(218)))));
       this.textBoxLargeImage.Font = new System.Drawing.Font("Arial", 11.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
       this.textBoxLargeImage.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(226)))), ((int)(((byte)(230)))), ((int)(((byte)(246)))));
-      this.textBoxLargeImage.Location = new System.Drawing.Point(18, 14);
-      this.textBoxLargeImage.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+      this.textBoxLargeImage.Location = new System.Drawing.Point(12, 9);
       this.textBoxLargeImage.Multiline = true;
       this.textBoxLargeImage.Name = "textBoxLargeImage";
-      this.textBoxLargeImage.Size = new System.Drawing.Size(133, 90);
+      this.textBoxLargeImage.Size = new System.Drawing.Size(90, 60);
       this.textBoxLargeImage.TabIndex = 0;
       this.textBoxLargeImage.Text = "Large Image Text";
-      // 
+      //
       // checkBoxTextOnly
-      // 
+      //
       this.checkBoxTextOnly.AutoSize = true;
-      this.checkBoxTextOnly.Location = new System.Drawing.Point(399, 140);
-      this.checkBoxTextOnly.Margin = new System.Windows.Forms.Padding(6);
+      this.checkBoxTextOnly.Location = new System.Drawing.Point(266, 91);
+      this.checkBoxTextOnly.Margin = new System.Windows.Forms.Padding(4);
       this.checkBoxTextOnly.Name = "checkBoxTextOnly";
-      this.checkBoxTextOnly.Padding = new System.Windows.Forms.Padding(3);
-      this.checkBoxTextOnly.Size = new System.Drawing.Size(261, 30);
+      this.checkBoxTextOnly.Padding = new System.Windows.Forms.Padding(2);
+      this.checkBoxTextOnly.Size = new System.Drawing.Size(176, 21);
       this.checkBoxTextOnly.TabIndex = 7;
       this.checkBoxTextOnly.Text = "Remove images from presence";
       this.checkBoxTextOnly.UseVisualStyleBackColor = true;
-      // 
+      //
       // checkBoxShowRemainingTime
-      // 
+      //
       this.checkBoxShowRemainingTime.AutoSize = true;
-      this.checkBoxShowRemainingTime.Location = new System.Drawing.Point(399, 98);
-      this.checkBoxShowRemainingTime.Margin = new System.Windows.Forms.Padding(6);
+      this.checkBoxShowRemainingTime.Location = new System.Drawing.Point(266, 64);
+      this.checkBoxShowRemainingTime.Margin = new System.Windows.Forms.Padding(4);
       this.checkBoxShowRemainingTime.Name = "checkBoxShowRemainingTime";
-      this.checkBoxShowRemainingTime.Padding = new System.Windows.Forms.Padding(3);
-      this.checkBoxShowRemainingTime.Size = new System.Drawing.Size(322, 30);
+      this.checkBoxShowRemainingTime.Padding = new System.Windows.Forms.Padding(2);
+      this.checkBoxShowRemainingTime.Size = new System.Drawing.Size(216, 21);
       this.checkBoxShowRemainingTime.TabIndex = 6;
       this.checkBoxShowRemainingTime.Text = "Show remaining instead of elapsed time";
       this.checkBoxShowRemainingTime.UseVisualStyleBackColor = true;
-      // 
+      //
       // checkBoxPresenceUpdate
-      // 
+      //
       this.checkBoxPresenceUpdate.AutoSize = true;
-      this.checkBoxPresenceUpdate.Location = new System.Drawing.Point(399, 9);
-      this.checkBoxPresenceUpdate.Margin = new System.Windows.Forms.Padding(6);
+      this.checkBoxPresenceUpdate.Location = new System.Drawing.Point(266, 6);
+      this.checkBoxPresenceUpdate.Margin = new System.Windows.Forms.Padding(4);
       this.checkBoxPresenceUpdate.Name = "checkBoxPresenceUpdate";
-      this.checkBoxPresenceUpdate.Padding = new System.Windows.Forms.Padding(3);
-      this.checkBoxPresenceUpdate.Size = new System.Drawing.Size(328, 30);
+      this.checkBoxPresenceUpdate.Padding = new System.Windows.Forms.Padding(2);
+      this.checkBoxPresenceUpdate.Size = new System.Drawing.Size(224, 21);
       this.checkBoxPresenceUpdate.TabIndex = 5;
       this.checkBoxPresenceUpdate.Text = "Show presence when no music is playing";
       this.checkBoxPresenceUpdate.UseVisualStyleBackColor = true;
-      // 
+      //
       // textBoxSeperator
-      // 
+      //
       this.textBoxSeperator.Font = new System.Drawing.Font("Arial", 11.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-      this.textBoxSeperator.Location = new System.Drawing.Point(130, 5);
-      this.textBoxSeperator.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+      this.textBoxSeperator.Location = new System.Drawing.Point(87, 3);
       this.textBoxSeperator.Name = "textBoxSeperator";
-      this.textBoxSeperator.Size = new System.Drawing.Size(128, 33);
+      this.textBoxSeperator.Size = new System.Drawing.Size(87, 25);
       this.textBoxSeperator.TabIndex = 4;
-      // 
+      //
       // label5
-      // 
+      //
       this.label5.AutoSize = true;
       this.label5.Font = new System.Drawing.Font("Microsoft Sans Serif", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-      this.label5.Location = new System.Drawing.Point(21, 11);
-      this.label5.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+      this.label5.Location = new System.Drawing.Point(14, 7);
       this.label5.Name = "label5";
-      this.label5.Size = new System.Drawing.Size(103, 22);
+      this.label5.Size = new System.Drawing.Size(70, 15);
       this.label5.TabIndex = 0;
       this.label5.Text = "Seperators:";
-      // 
+      //
       // buttonRestoreDefaults
-      // 
+      //
       this.buttonRestoreDefaults.AutoSize = true;
       this.buttonRestoreDefaults.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
       this.buttonRestoreDefaults.Dock = System.Windows.Forms.DockStyle.Right;
-      this.buttonRestoreDefaults.Location = new System.Drawing.Point(462, 0);
-      this.buttonRestoreDefaults.Margin = new System.Windows.Forms.Padding(15);
+      this.buttonRestoreDefaults.Location = new System.Drawing.Point(316, 0);
+      this.buttonRestoreDefaults.Margin = new System.Windows.Forms.Padding(10);
       this.buttonRestoreDefaults.Name = "buttonRestoreDefaults";
-      this.buttonRestoreDefaults.Padding = new System.Windows.Forms.Padding(8);
-      this.buttonRestoreDefaults.Size = new System.Drawing.Size(156, 46);
+      this.buttonRestoreDefaults.Padding = new System.Windows.Forms.Padding(5);
+      this.buttonRestoreDefaults.Size = new System.Drawing.Size(106, 30);
       this.buttonRestoreDefaults.TabIndex = 2;
       this.buttonRestoreDefaults.Text = "Restore Defaults";
       this.buttonRestoreDefaults.UseVisualStyleBackColor = true;
       this.buttonRestoreDefaults.Click += new System.EventHandler(this.buttonRestoreDefaults_Click);
-      // 
+      //
       // buttonSaveClose
-      // 
+      //
       this.buttonSaveClose.AutoSize = true;
       this.buttonSaveClose.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
       this.buttonSaveClose.Dock = System.Windows.Forms.DockStyle.Right;
-      this.buttonSaveClose.Location = new System.Drawing.Point(618, 0);
-      this.buttonSaveClose.Margin = new System.Windows.Forms.Padding(15);
+      this.buttonSaveClose.Location = new System.Drawing.Point(422, 0);
+      this.buttonSaveClose.Margin = new System.Windows.Forms.Padding(10);
       this.buttonSaveClose.Name = "buttonSaveClose";
-      this.buttonSaveClose.Padding = new System.Windows.Forms.Padding(8);
-      this.buttonSaveClose.Size = new System.Drawing.Size(146, 46);
+      this.buttonSaveClose.Padding = new System.Windows.Forms.Padding(5);
+      this.buttonSaveClose.Size = new System.Drawing.Size(102, 30);
       this.buttonSaveClose.TabIndex = 0;
       this.buttonSaveClose.Text = "Save and Close";
       this.buttonSaveClose.UseVisualStyleBackColor = true;
       this.buttonSaveClose.Click += new System.EventHandler(this.buttonSaveClose_Click);
-      // 
+      //
       // buttonPlaceholders
-      // 
+      //
       this.buttonPlaceholders.AutoSize = true;
       this.buttonPlaceholders.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
       this.buttonPlaceholders.Dock = System.Windows.Forms.DockStyle.Left;
       this.buttonPlaceholders.Location = new System.Drawing.Point(0, 0);
-      this.buttonPlaceholders.Margin = new System.Windows.Forms.Padding(15);
+      this.buttonPlaceholders.Margin = new System.Windows.Forms.Padding(10);
       this.buttonPlaceholders.Name = "buttonPlaceholders";
-      this.buttonPlaceholders.Padding = new System.Windows.Forms.Padding(8);
-      this.buttonPlaceholders.Size = new System.Drawing.Size(126, 46);
+      this.buttonPlaceholders.Padding = new System.Windows.Forms.Padding(5);
+      this.buttonPlaceholders.Size = new System.Drawing.Size(88, 30);
       this.buttonPlaceholders.TabIndex = 1;
       this.buttonPlaceholders.Text = "Placeholders";
       this.buttonPlaceholders.UseVisualStyleBackColor = true;
       this.buttonPlaceholders.Click += new System.EventHandler(this.buttonPlaceholders_Click);
-      // 
+      //
       // panel2
-      // 
+      //
       this.panel2.AutoSize = true;
       this.panel2.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+      this.panel2.Controls.Add(this.customButtonToggle);
       this.panel2.Controls.Add(this.checkBoxShowOnlyNonPlayingState);
       this.panel2.Controls.Add(this.checkBoxShowPlayState);
       this.panel2.Controls.Add(this.checkBoxShowTime);
@@ -307,78 +299,101 @@ namespace MusicBeePlugin
       this.panel2.Controls.Add(this.checkBoxTextOnly);
       this.panel2.Controls.Add(this.checkBoxPresenceUpdate);
       this.panel2.Dock = System.Windows.Forms.DockStyle.Fill;
-      this.panel2.Location = new System.Drawing.Point(0, 163);
-      this.panel2.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-      this.panel2.MinimumSize = new System.Drawing.Size(0, 154);
+      this.panel2.Location = new System.Drawing.Point(0, 157);
+      this.panel2.MinimumSize = new System.Drawing.Size(0, 100);
       this.panel2.Name = "panel2";
-      this.panel2.Size = new System.Drawing.Size(764, 225);
+      this.panel2.Size = new System.Drawing.Size(524, 159);
       this.panel2.TabIndex = 1;
-      // 
+      //
+      // customButtonToggle
+      //
+      this.customButtonToggle.AutoSize = true;
+      this.customButtonToggle.Location = new System.Drawing.Point(266, 118);
+      this.customButtonToggle.Margin = new System.Windows.Forms.Padding(4);
+      this.customButtonToggle.Name = "customButtonToggle";
+      this.customButtonToggle.Padding = new System.Windows.Forms.Padding(2);
+      this.customButtonToggle.Size = new System.Drawing.Size(135, 21);
+      this.customButtonToggle.TabIndex = 18;
+      this.customButtonToggle.Text = "Enable Custom Button";
+      this.customButtonToggle.UseVisualStyleBackColor = true;
+      //
+      // checkBoxShowOnlyNonPlayingState
+      //
+      this.checkBoxShowOnlyNonPlayingState.AutoSize = true;
+      this.checkBoxShowOnlyNonPlayingState.Checked = true;
+      this.checkBoxShowOnlyNonPlayingState.CheckState = System.Windows.Forms.CheckState.Checked;
+      this.checkBoxShowOnlyNonPlayingState.Location = new System.Drawing.Point(17, 118);
+      this.checkBoxShowOnlyNonPlayingState.Margin = new System.Windows.Forms.Padding(4);
+      this.checkBoxShowOnlyNonPlayingState.Name = "checkBoxShowOnlyNonPlayingState";
+      this.checkBoxShowOnlyNonPlayingState.Padding = new System.Windows.Forms.Padding(2);
+      this.checkBoxShowOnlyNonPlayingState.Size = new System.Drawing.Size(210, 21);
+      this.checkBoxShowOnlyNonPlayingState.TabIndex = 13;
+      this.checkBoxShowOnlyNonPlayingState.Text = "Don\'t show playing state when playing";
+      this.checkBoxShowOnlyNonPlayingState.UseVisualStyleBackColor = true;
+      //
       // checkBoxShowPlayState
-      // 
+      //
       this.checkBoxShowPlayState.AutoSize = true;
       this.checkBoxShowPlayState.Checked = true;
       this.checkBoxShowPlayState.CheckState = System.Windows.Forms.CheckState.Checked;
-      this.checkBoxShowPlayState.Location = new System.Drawing.Point(26, 140);
-      this.checkBoxShowPlayState.Margin = new System.Windows.Forms.Padding(6);
+      this.checkBoxShowPlayState.Location = new System.Drawing.Point(17, 91);
+      this.checkBoxShowPlayState.Margin = new System.Windows.Forms.Padding(4);
       this.checkBoxShowPlayState.Name = "checkBoxShowPlayState";
-      this.checkBoxShowPlayState.Padding = new System.Windows.Forms.Padding(3);
-      this.checkBoxShowPlayState.Size = new System.Drawing.Size(285, 30);
+      this.checkBoxShowPlayState.Padding = new System.Windows.Forms.Padding(2);
+      this.checkBoxShowPlayState.Size = new System.Drawing.Size(195, 21);
       this.checkBoxShowPlayState.TabIndex = 12;
       this.checkBoxShowPlayState.Text = "Show playing state on album cover";
       this.checkBoxShowPlayState.UseVisualStyleBackColor = true;
-      // 
+      //
       // checkBoxShowTime
-      // 
+      //
       this.checkBoxShowTime.AutoSize = true;
       this.checkBoxShowTime.Checked = true;
       this.checkBoxShowTime.CheckState = System.Windows.Forms.CheckState.Checked;
-      this.checkBoxShowTime.Location = new System.Drawing.Point(399, 53);
-      this.checkBoxShowTime.Margin = new System.Windows.Forms.Padding(6);
+      this.checkBoxShowTime.Location = new System.Drawing.Point(266, 34);
+      this.checkBoxShowTime.Margin = new System.Windows.Forms.Padding(4);
       this.checkBoxShowTime.Name = "checkBoxShowTime";
-      this.checkBoxShowTime.Padding = new System.Windows.Forms.Padding(3);
-      this.checkBoxShowTime.Size = new System.Drawing.Size(115, 30);
+      this.checkBoxShowTime.Padding = new System.Windows.Forms.Padding(2);
+      this.checkBoxShowTime.Size = new System.Drawing.Size(79, 21);
       this.checkBoxShowTime.TabIndex = 11;
       this.checkBoxShowTime.Text = "Show time";
       this.checkBoxShowTime.UseVisualStyleBackColor = true;
-      // 
+      //
       // checkBoxArtworkUpload
-      // 
+      //
       this.checkBoxArtworkUpload.AutoSize = true;
       this.checkBoxArtworkUpload.BackColor = System.Drawing.Color.White;
-      this.checkBoxArtworkUpload.Location = new System.Drawing.Point(26, 98);
-      this.checkBoxArtworkUpload.Margin = new System.Windows.Forms.Padding(6);
+      this.checkBoxArtworkUpload.Location = new System.Drawing.Point(17, 64);
+      this.checkBoxArtworkUpload.Margin = new System.Windows.Forms.Padding(4);
       this.checkBoxArtworkUpload.Name = "checkBoxArtworkUpload";
-      this.checkBoxArtworkUpload.Padding = new System.Windows.Forms.Padding(3);
-      this.checkBoxArtworkUpload.Size = new System.Drawing.Size(370, 30);
+      this.checkBoxArtworkUpload.Padding = new System.Windows.Forms.Padding(2);
+      this.checkBoxArtworkUpload.Size = new System.Drawing.Size(249, 21);
       this.checkBoxArtworkUpload.TabIndex = 10;
       this.checkBoxArtworkUpload.Text = "Upload album covers (requires custom App ID)";
       this.checkBoxArtworkUpload.UseVisualStyleBackColor = false;
       this.checkBoxArtworkUpload.CheckedChanged += new System.EventHandler(this.checkBoxArtworkUpload_CheckedChanged);
-      // 
+      //
       // labelDiscordAppId
-      // 
+      //
       this.labelDiscordAppId.AutoSize = true;
       this.labelDiscordAppId.Font = new System.Drawing.Font("Microsoft Sans Serif", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-      this.labelDiscordAppId.Location = new System.Drawing.Point(21, 55);
-      this.labelDiscordAppId.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+      this.labelDiscordAppId.Location = new System.Drawing.Point(14, 36);
       this.labelDiscordAppId.Name = "labelDiscordAppId";
-      this.labelDiscordAppId.Size = new System.Drawing.Size(135, 22);
+      this.labelDiscordAppId.Size = new System.Drawing.Size(91, 15);
       this.labelDiscordAppId.TabIndex = 8;
       this.labelDiscordAppId.Text = "Discord App ID:";
-      // 
+      //
       // textBoxDiscordAppId
-      // 
+      //
       this.textBoxDiscordAppId.Font = new System.Drawing.Font("Arial", 11.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-      this.textBoxDiscordAppId.Location = new System.Drawing.Point(162, 49);
-      this.textBoxDiscordAppId.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+      this.textBoxDiscordAppId.Location = new System.Drawing.Point(108, 32);
       this.textBoxDiscordAppId.Name = "textBoxDiscordAppId";
-      this.textBoxDiscordAppId.Size = new System.Drawing.Size(224, 33);
+      this.textBoxDiscordAppId.Size = new System.Drawing.Size(151, 25);
       this.textBoxDiscordAppId.TabIndex = 9;
       this.textBoxDiscordAppId.TextChanged += new System.EventHandler(this.textBoxDiscordAppId_TextChanged);
-      // 
+      //
       // panel3
-      // 
+      //
       this.panel3.AutoScroll = true;
       this.panel3.AutoSize = true;
       this.panel3.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
@@ -386,17 +401,20 @@ namespace MusicBeePlugin
       this.panel3.Controls.Add(this.buttonPlaceholders);
       this.panel3.Controls.Add(this.buttonSaveClose);
       this.panel3.Dock = System.Windows.Forms.DockStyle.Bottom;
-      this.panel3.Location = new System.Drawing.Point(0, 388);
-      this.panel3.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-      this.panel3.MinimumSize = new System.Drawing.Size(0, 46);
+      this.panel3.Location = new System.Drawing.Point(0, 316);
+      this.panel3.MinimumSize = new System.Drawing.Size(0, 30);
       this.panel3.Name = "panel3";
-      this.panel3.Size = new System.Drawing.Size(764, 46);
+      this.panel3.Size = new System.Drawing.Size(524, 30);
       this.panel3.TabIndex = 2;
-      // 
+      //
       // panel4
-      // 
+      //
       this.panel4.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
       this.panel4.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(114)))), ((int)(((byte)(137)))), ((int)(((byte)(218)))));
+      this.panel4.Controls.Add(this.label9);
+      this.panel4.Controls.Add(this.customButtonUrl);
+      this.panel4.Controls.Add(this.label8);
+      this.panel4.Controls.Add(this.customButtonLabel);
       this.panel4.Controls.Add(this.textBoxSmallImage);
       this.panel4.Controls.Add(this.textBoxLargeImage);
       this.panel4.Controls.Add(this.label4);
@@ -409,37 +427,65 @@ namespace MusicBeePlugin
       this.panel4.Controls.Add(this.label2);
       this.panel4.Dock = System.Windows.Forms.DockStyle.Top;
       this.panel4.Location = new System.Drawing.Point(0, 0);
-      this.panel4.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
       this.panel4.Name = "panel4";
-      this.panel4.Size = new System.Drawing.Size(764, 163);
+      this.panel4.Size = new System.Drawing.Size(524, 157);
       this.panel4.TabIndex = 1;
-      // 
-      // checkBoxShowOnlyNonPlayingState
-      // 
-      this.checkBoxShowOnlyNonPlayingState.AutoSize = true;
-      this.checkBoxShowOnlyNonPlayingState.Checked = true;
-      this.checkBoxShowOnlyNonPlayingState.CheckState = System.Windows.Forms.CheckState.Checked;
-      this.checkBoxShowOnlyNonPlayingState.Location = new System.Drawing.Point(26, 182);
-      this.checkBoxShowOnlyNonPlayingState.Margin = new System.Windows.Forms.Padding(6);
-      this.checkBoxShowOnlyNonPlayingState.Name = "checkBoxShowOnlyNonPlayingState";
-      this.checkBoxShowOnlyNonPlayingState.Padding = new System.Windows.Forms.Padding(3);
-      this.checkBoxShowOnlyNonPlayingState.Size = new System.Drawing.Size(308, 30);
-      this.checkBoxShowOnlyNonPlayingState.TabIndex = 13;
-      this.checkBoxShowOnlyNonPlayingState.Text = "Don\'t show playing state when playing";
-      this.checkBoxShowOnlyNonPlayingState.UseVisualStyleBackColor = true;
-      // 
+      //
+      // label9
+      //
+      this.label9.AutoSize = true;
+      this.label9.Font = new System.Drawing.Font("Microsoft Sans Serif", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+      this.label9.ForeColor = System.Drawing.Color.White;
+      this.label9.Location = new System.Drawing.Point(198, 99);
+      this.label9.Name = "label9";
+      this.label9.Size = new System.Drawing.Size(241, 15);
+      this.label9.TabIndex = 19;
+      this.label9.Text = "Custom Button Url (Supports Placeholders)";
+      //
+      // customButtonUrl
+      //
+      this.customButtonUrl.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) | System.Windows.Forms.AnchorStyles.Right)));
+      this.customButtonUrl.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(114)))), ((int)(((byte)(137)))), ((int)(((byte)(218)))));
+      this.customButtonUrl.Font = new System.Drawing.Font("Arial", 11.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+      this.customButtonUrl.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(226)))), ((int)(((byte)(230)))), ((int)(((byte)(246)))));
+      this.customButtonUrl.Location = new System.Drawing.Point(198, 117);
+      this.customButtonUrl.Name = "customButtonUrl";
+      this.customButtonUrl.Size = new System.Drawing.Size(290, 25);
+      this.customButtonUrl.TabIndex = 20;
+      this.customButtonUrl.TextChanged += new System.EventHandler(this.customButtonUrl_TextChanged);
+      //
+      // label8
+      //
+      this.label8.AutoSize = true;
+      this.label8.Font = new System.Drawing.Font("Microsoft Sans Serif", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+      this.label8.ForeColor = System.Drawing.Color.White;
+      this.label8.Location = new System.Drawing.Point(9, 99);
+      this.label8.Name = "label8";
+      this.label8.Size = new System.Drawing.Size(124, 15);
+      this.label8.TabIndex = 19;
+      this.label8.Text = "Custom Button Label:";
+      //
+      // customButtonLabel
+      //
+      this.customButtonLabel.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(114)))), ((int)(((byte)(137)))), ((int)(((byte)(218)))));
+      this.customButtonLabel.Font = new System.Drawing.Font("Arial", 11.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+      this.customButtonLabel.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(226)))), ((int)(((byte)(230)))), ((int)(((byte)(246)))));
+      this.customButtonLabel.Location = new System.Drawing.Point(12, 117);
+      this.customButtonLabel.Name = "customButtonLabel";
+      this.customButtonLabel.Size = new System.Drawing.Size(177, 25);
+      this.customButtonLabel.TabIndex = 10;
+      //
       // SettingsWindow
-      // 
-      this.AutoScaleDimensions = new System.Drawing.SizeF(9F, 20F);
+      //
+      this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
       this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
       this.AutoSize = true;
       this.BackColor = System.Drawing.Color.White;
-      this.ClientSize = new System.Drawing.Size(764, 434);
+      this.ClientSize = new System.Drawing.Size(524, 346);
       this.Controls.Add(this.panel2);
       this.Controls.Add(this.panel3);
       this.Controls.Add(this.panel4);
-      this.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-      this.MinimumSize = new System.Drawing.Size(776, 401);
+      this.MinimumSize = new System.Drawing.Size(523, 274);
       this.Name = "SettingsWindow";
       this.ShowIcon = false;
       this.Text = "DiscordBee Settings";
@@ -451,8 +497,13 @@ namespace MusicBeePlugin
       this.panel4.PerformLayout();
       this.ResumeLayout(false);
       this.PerformLayout();
-
     }
+
+    private System.Windows.Forms.TextBox customButtonUrl;
+    private System.Windows.Forms.Label label9;
+    private System.Windows.Forms.Label label8;
+    private System.Windows.Forms.CheckBox customButtonToggle;
+    private System.Windows.Forms.TextBox customButtonLabel;
 
     #endregion
     private System.Windows.Forms.TextBox textBoxLargeImage;

--- a/SettingsWindow.cs
+++ b/SettingsWindow.cs
@@ -1,6 +1,7 @@
 namespace MusicBeePlugin
 {
   using System;
+  using System.Drawing;
   using System.Windows.Forms;
 
   public partial class SettingsWindow : Form
@@ -64,6 +65,9 @@ namespace MusicBeePlugin
       checkBoxShowPlayState.Checked = settings.ShowPlayState;
       checkBoxShowOnlyNonPlayingState.Checked = settings.ShowOnlyNonPlayingState;
       checkBoxArtworkUpload.Checked = settings.UploadArtwork;
+      customButtonLabel.Text = settings.ButtonLabel;
+      customButtonUrl.Text = settings.ButtonUrl;
+      customButtonToggle.Checked = settings.ShowButton;
 
       ValidateInputs();
     }
@@ -104,6 +108,9 @@ namespace MusicBeePlugin
       _settings.ShowPlayState = checkBoxShowPlayState.Checked;
       _settings.ShowOnlyNonPlayingState = checkBoxShowOnlyNonPlayingState.Checked;
       _settings.UploadArtwork = checkBoxArtworkUpload.Checked;
+      _settings.ButtonUrl = customButtonUrl.Text;
+      _settings.ButtonLabel = customButtonLabel.Text;
+      _settings.ShowButton = customButtonToggle.Checked;
 
       if (_defaultsRestored && !_settings.IsDirty)
       {
@@ -135,10 +142,10 @@ namespace MusicBeePlugin
           || textBoxDiscordAppId.Text.Equals(Settings.defaults["DiscordAppId"])
           || !ContainsDigitsOnly(textBoxDiscordAppId.Text))
         {
-          textBoxDiscordAppId.BackColor = System.Drawing.Color.PaleVioletRed;
+          textBoxDiscordAppId.BackColor = Color.PaleVioletRed;
           return false;
         }
-        textBoxDiscordAppId.BackColor = System.Drawing.Color.White;
+        textBoxDiscordAppId.BackColor = Color.White;
         return true;
       }
 
@@ -152,6 +159,23 @@ namespace MusicBeePlugin
         return false;
       }
 
+      bool validateUri()
+      {
+        if (!ValidationHelpers.ValidateUri(customButtonUrl.Text))
+        {
+          customButtonUrl.BackColor = Color.PaleVioletRed;
+          return false;
+        }
+
+        customButtonUrl.BackColor = Color.FromArgb(114, 137, 218);
+        return true;
+      }
+
+      if (!validateUri())
+      {
+        return false;
+      }
+
       ResetErrorIndications();
 
       return true;
@@ -159,7 +183,8 @@ namespace MusicBeePlugin
 
     private void ResetErrorIndications()
     {
-      textBoxDiscordAppId.BackColor = System.Drawing.Color.White;
+      textBoxDiscordAppId.BackColor = Color.White;
+      customButtonUrl.BackColor = Color.FromArgb(114, 137, 218);
     }
 
     private void textBoxDiscordAppId_TextChanged(object sender, EventArgs e)
@@ -168,6 +193,11 @@ namespace MusicBeePlugin
     }
 
     private void checkBoxArtworkUpload_CheckedChanged(object sender, EventArgs e)
+    {
+      ValidateInputs();
+    }
+
+    private void customButtonUrl_TextChanged(object sender, EventArgs e)
     {
       ValidateInputs();
     }

--- a/ValidationHelpers.cs
+++ b/ValidationHelpers.cs
@@ -1,0 +1,13 @@
+﻿namespace MusicBeePlugin
+{
+  using System;
+
+  public static class ValidationHelpers
+  {
+    public static bool ValidateUri(string uri)
+    {
+      return Uri.TryCreate(uri, UriKind.Absolute, out Uri uriValidation)
+             && (uriValidation.Scheme == Uri.UriSchemeHttp || uriValidation.Scheme == Uri.UriSchemeHttps);
+    }
+  }
+}


### PR DESCRIPTION
Implements Custom Button Support

![image](https://user-images.githubusercontent.com/35658068/161994449-34f13c27-b8bd-4df4-a992-0104f8f431ed.png)
![image](https://user-images.githubusercontent.com/35658068/161994528-a7bab171-b3a0-46fe-b6b8-11578e0c1abb.png)

There some users might want to add some links directing to either a streaming service, metadata database, etc. to mimick Spotify Rich Presence.

By default it is disabled and users can enable them if they want to. By default the buttons redirect them to the song's last.fm page.