### PR TITLE
Add file extension placeholder

### DIFF
--- a/DiscordBee.cs
+++ b/DiscordBee.cs
@@ -214,6 +214,7 @@ namespace MusicBeePlugin
       {
         ret.Add(elem.ToString(), string.IsNullOrWhiteSpace(fileUrl) ? _mbApiInterface.NowPlaying_GetFileProperty(elem) : _mbApiInterface.Library_GetFileProperty(fileUrl, elem));
       }
+      ret.Add("Extension", Path.GetExtension(string.IsNullOrWhiteSpace(fileUrl) ? _mbApiInterface.NowPlaying_GetFileUrl() : fileUrl).TrimStart('.').ToUpper());
       ret.Add("PlayState", _mbApiInterface.Player_GetPlayState().ToString());
       ret.Add("Volume", Convert.ToInt32(_mbApiInterface.Player_GetVolume() * 100.0f).ToString());
 


### PR DESCRIPTION
Adds a placeholder for the file extension (like what's displayed in MusicBee's Track Information panel), since values from `FilePropertyType.Kind` are needlessly long and don't always match the file extension (e.g. MP3 and M4A showing as "MPEG audio file" and "AAC audio file" respectively).

Sidenote - is `GenerateMetaDataDictionary`'s `fileUrl` argument added in c96e9f2 supposed to be used for anything? I accommodated for it here (which makes the one-liner look pretty ugly), but this arg never gets passed to it by any references.